### PR TITLE
Update webpack.dev.js to import images in JS

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -34,7 +34,8 @@ module.exports = {
   resolve: {
     alias: {
       'js': path.join(root, 'src/js'),
-      'css': path.join(root, 'src/css')
+      'css': path.join(root, 'src/css'),
+      'images': path.join(root, 'src/images')
     }
   },
   plugins: [
@@ -54,6 +55,12 @@ module.exports = {
     }, {
       test: /\.scss$/,
       loaders: ['style', 'css', 'sass']
+    }, {
+      test: /\.(jpe?g|png|gif|svg)$/i,
+      loaders: [
+          'file?hash=sha512&digest=hex&name=[hash].[ext]',
+          'image-webpack?bypassOnDebug&optimizationLevel=7&interlaced=false'
+      ]
     }, {
       test: /\.js?$/,
       loader: 'babel',


### PR DESCRIPTION
Update webpack.dev.js to import iamges in JS

Supported images formats:
- jpeg
- png
- gif
- svg

Added alias to import files from 'src/images'

Example:
import logo from 'images/logo.png'