### PR TITLE
Added esri-specific mocks so we can fake the creation of an esri Map …

### DIFF
--- a/__mocks__/Map.js
+++ b/__mocks__/Map.js
@@ -1,0 +1,3 @@
+module.exports = function Map() {
+  return ('');
+};

--- a/__mocks__/MapView.js
+++ b/__mocks__/MapView.js
@@ -1,0 +1,3 @@
+module.exports = function MapView() {
+  return Promise.resolve({});
+};

--- a/__tests__/components/MapView.test.js
+++ b/__tests__/components/MapView.test.js
@@ -1,0 +1,21 @@
+import renderer from 'react-test-renderer';
+import MapView from 'js/components/MapView';
+import React from 'react';
+
+/**
+* Snapshot testing can be very useful if used correctly, this example just shows how to use
+* it but this is not the most useful snapshot, sometimes it is better to call it multiple
+* times inside a test and take snapshots of the component changing throughout some interactions,
+* Ex. snapshot default state, snapshot after click/mouseover, snapshot after mouseleave
+*/
+describe('MapView snapshot Tests', () => {
+
+  test('Sample of snapshot testing, not very useful, but shows how to do it', () => {
+    const header = renderer.create(
+      <MapView title="Snapshot Test #1" subtitle="Test output over time in your component" />
+    );
+    const tree = header.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+});

--- a/__tests__/components/MapView.test.js
+++ b/__tests__/components/MapView.test.js
@@ -3,16 +3,17 @@ import MapView from 'js/components/MapView';
 import React from 'react';
 
 /**
-* Snapshot testing can be very useful if used correctly, this example just shows how to use
-* it but this is not the most useful snapshot, sometimes it is better to call it multiple
-* times inside a test and take snapshots of the component changing throughout some interactions,
-* Ex. snapshot default state, snapshot after click/mouseover, snapshot after mouseleave
+* Snapshot testing can be very useful if used correctly, but sometimesits pretty tough to do
+when you are including 3rd party libraries via generic 'import' statements. Unless addressed
+properly, Jest will try to path them explicitly and it will be zero fun setting them up after
+you've written a bunch of code. Here we run a test on a higher level component that has hard
+esri dependencies.
 */
 describe('MapView snapshot Tests', () => {
 
-  test('Sample of snapshot testing, not very useful, but shows how to do it', () => {
+  test('Sample of snapshot testing for 3rd party components', () => {
     const header = renderer.create(
-      <MapView title="Snapshot Test #1" subtitle="Test output over time in your component" />
+      <MapView />
     );
     const tree = header.toJSON();
     expect(tree).toMatchSnapshot();

--- a/__tests__/components/__snapshots__/MapView.test.js.snap
+++ b/__tests__/components/__snapshots__/MapView.test.js.snap
@@ -1,0 +1,294 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MapView snapshot Tests Sample of snapshot testing, not very useful, but shows how to do it 1`] = `
+<div
+  className="map-view"
+>
+  <div
+    className="map-controls shadow"
+  >
+    <ul
+      className="map-controls__list"
+    >
+      <li
+        className="map-controls__item pointer"
+        onClick={[Function]}
+      >
+        <svg
+          aria-label="Zoom out"
+          className="map-controls__item-icon"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<use xlink:href=\\"#icon-zoom-out\\" />",
+            }
+          }
+          role="img"
+        />
+      </li>
+      <li
+        className="map-controls__item pointer"
+        onClick={[Function]}
+      >
+        <svg
+          aria-label="Zoom in"
+          className="map-controls__item-icon"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<use xlink:href=\\"#icon-zoom-in\\" />",
+            }
+          }
+          role="img"
+        />
+      </li>
+      <li
+        className="map-controls__item pointer"
+        onClick={[Function]}
+      >
+        <svg
+          aria-label="Share your experience"
+          className="map-controls__item-icon"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<use xlink:href=\\"#icon-share\\" />",
+            }
+          }
+          role="img"
+        />
+      </li>
+      <li
+        className="map-controls__item pointer"
+        onClick={[Function]}
+      >
+        <svg
+          aria-label="Find my location"
+          className="map-controls__item-icon"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<use xlink:href=\\"#icon-locate\\" />",
+            }
+          }
+          role="img"
+        />
+      </li>
+    </ul>
+  </div>
+  <div
+    style={
+      Object {
+        "display": "block",
+        "height": "100%",
+        "left": 0,
+        "position": "absolute",
+        "top": 0,
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "height": "50px",
+          "left": "50%",
+          "position": "absolute",
+          "top": "50%",
+          "transform": "translate(-50%, -50%)",
+          "width": "50px",
+        }
+      }
+    >
+      <svg
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "
+                        <g transform='translate(25,25) rotate(-90)'>
+                          <path d=\\"M0,25A25,25 0 1,1 0,-25A25,25 0 1,1 0,25M0,20A20,20 0 1,0 0,-20A20,20 0 1,0 0,20Z\\" style=\\"fill:transparent\\"></path>
+                          <path
+                            d=\\"M1.5308084989341915e-15,-25A25,25 0 0,1 25,0L20,0A20,20 0 0,0 1.2246467991473533e-15,-20Z\\"
+                            transform=\\"rotate(709.287459262793)\\"
+                            style=\\"animation: spinner 0.95s cubic-bezier(0.645, 0.045, 0.355, 1.000) infinite;fill: #FFFFFF;\\">
+                          </path>
+                        </g>
+                      ",
+          }
+        }
+        height="50"
+        width="50"
+      />
+    </div>
+  </div>
+  <div
+    style={
+      Object {
+        "display": "none",
+        "height": "100%",
+        "left": 0,
+        "position": "fixed",
+        "top": 0,
+        "width": "100%",
+        "zIndex": 10,
+      }
+    }
+  >
+    <div
+      onClick={[Function]}
+      style={
+        Object {
+          "backgroundColor": "rgba(0, 0, 0, 0.25)",
+          "height": "100%",
+          "width": "100%",
+        }
+      }
+    />
+    <article
+      className="share-modal"
+      style={
+        Object {
+          "backgroundColor": "white",
+          "height": "auto",
+          "left": "50%",
+          "padding": "30px",
+          "position": "absolute",
+          "top": "50%",
+          "transform": "translate(-50%, -50%)",
+        }
+      }
+    >
+      <div
+        onClick={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "display": "flex",
+            "height": "30px",
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "width": "30px",
+          }
+        }
+        title="close"
+      >
+        <svg
+          style={
+            Object {
+              "fill": "#555555",
+              "height": "26px",
+              "margin": "auto",
+              "width": "26px",
+            }
+          }
+          viewBox="0 0 25 25"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            d="M 5 19 L 19 5 L 21 7 L 7 21 L 5 19 ZM 7 5 L 21 19 L 19 21 L 5 7 L 7 5 Z"
+          />
+        </svg>
+      </div>
+      <div
+        style={
+          Object {
+            "maxHeight": "450px",
+            "overflowX": "hidden",
+            "overflowY": "auto",
+            "padding": "5px",
+          }
+        }
+      >
+        <h3>
+          Share Something
+        </h3>
+      </div>
+    </article>
+  </div>
+  <div
+    style={
+      Object {
+        "display": "none",
+        "height": "100%",
+        "left": 0,
+        "position": "fixed",
+        "top": 0,
+        "width": "100%",
+        "zIndex": 10,
+      }
+    }
+  >
+    <div
+      onClick={[Function]}
+      style={
+        Object {
+          "backgroundColor": "rgba(0, 0, 0, 0.25)",
+          "height": "100%",
+          "width": "100%",
+        }
+      }
+    />
+    <article
+      className="locate-modal"
+      style={
+        Object {
+          "backgroundColor": "white",
+          "height": "auto",
+          "left": "50%",
+          "padding": "30px",
+          "position": "absolute",
+          "top": "50%",
+          "transform": "translate(-50%, -50%)",
+        }
+      }
+    >
+      <div
+        onClick={[Function]}
+        style={
+          Object {
+            "cursor": "pointer",
+            "display": "flex",
+            "height": "30px",
+            "position": "absolute",
+            "right": 0,
+            "top": 0,
+            "width": "30px",
+          }
+        }
+        title="close"
+      >
+        <svg
+          style={
+            Object {
+              "fill": "#555555",
+              "height": "26px",
+              "margin": "auto",
+              "width": "26px",
+            }
+          }
+          viewBox="0 0 25 25"
+        >
+          <title>
+            Close
+          </title>
+          <path
+            d="M 5 19 L 19 5 L 21 7 L 7 21 L 5 19 ZM 7 5 L 21 19 L 19 21 L 5 7 L 7 5 Z"
+          />
+        </svg>
+      </div>
+      <div
+        style={
+          Object {
+            "maxHeight": "450px",
+            "overflowX": "hidden",
+            "overflowY": "auto",
+            "padding": "5px",
+          }
+        }
+      >
+        <h3>
+          Locate Something
+        </h3>
+      </div>
+    </article>
+  </div>
+</div>
+`;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "moduleNameMapper": {
       "^js(.*)$": "<rootDir>/src/js$1",
       "^dojo(.*)$": "<rootDir>/__mocks__/arcgis.js",
-      "^esri(.*)$": "<rootDir>/__mocks__/arcgis.js",
+      "esri/request": "<rootDir>/__mocks__/MapView.js",
+      "esri/views/MapView": "<rootDir>/__mocks__/MapView.js",
+      "esri/Map": "<rootDir>/__mocks__/Map.js",
       "^dijit(.*)$": "<rootDir>/__mocks__/arcgis.js",
       "\\.(css|scss)$": "<rootDir>/__mocks__/style.js",
       "\\.(jpe?g|png|gif|svg)$": "<rootDir>/__mocks__/static.js"


### PR DESCRIPTION
…and MapView

This PR is specifically designed to enable the testing of any 3rd-party module that runs some type of Constructor. 

When we import our MapView into any file, that import immediately fails due to the new MapView constructor in the file's ComponentDidMount. In order to get past this and test the rest our application, we need to mock out an ESRI MapView. To do this, we bypass our jest's moduleNameMapper and specify a specific Mock, one which returns a Promise like a MapView. I did the same, minus the Promise, for the esri/Map module as its Constructor returns a simple object.

While this update has the annoying disadvantage of spec'ing out any esri module you use in our mocks folder, we can now easily test the rest of the application, and any 3rd-party module that contains a Constructor. 

<img width="570" alt="passing" src="https://cloud.githubusercontent.com/assets/5713523/23481479/82a2c648-fe99-11e6-9c0d-87f5879cd0c5.png">
